### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/ktomy/nsromania-setup/security/code-scanning/1](https://github.com/ktomy/nsromania-setup/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function. Based on the tasks performed in the workflow, the `contents: read` permission is sufficient, as the workflow only needs to read the repository's contents to run tests and build the application. No write permissions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
